### PR TITLE
MarsBaseBuilder: update MonoGame version

### DIFF
--- a/MarsBaseBuilder.Tests/MarsBaseBuilder.Tests.fsproj
+++ b/MarsBaseBuilder.Tests/MarsBaseBuilder.Tests.fsproj
@@ -56,6 +56,7 @@
     <Compile Include="RendererTests.fs" />
     <Content Include="packages.config" />
     <Content Include="App.config" />
+    <Content Include="MonoGame.Framework.dll.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Foq">
@@ -65,15 +66,9 @@
       <HintPath>..\packages\FSharp.Core.4.1.17\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="MonoGame.Framework">
-      <HintPath>..\packages\MonoGame.Framework.DesktopGL.3.5.1.1679\lib\net40\MonoGame.Framework.dll</HintPath>
+      <HintPath>..\packages\MonoGame.Framework.DesktopGL.3.6.0.1625\lib\net40\MonoGame.Framework.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="NVorbis">
-      <HintPath>..\packages\MonoGame.Framework.DesktopGL.3.5.1.1679\lib\net40\NVorbis.dll</HintPath>
-    </Reference>
-    <Reference Include="OpenTK">
-      <HintPath>..\packages\MonoGame.Framework.DesktopGL.3.5.1.1679\lib\net40\OpenTK.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />

--- a/MarsBaseBuilder.Tests/MonoGame.Framework.dll.config
+++ b/MarsBaseBuilder.Tests/MonoGame.Framework.dll.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<dllmap dll="SDL2.dll" os="osx" target="libSDL2-2.0.0.dylib"/>
+	<dllmap dll="soft_oal.dll" os="osx" target="libopenal.1.dylib" />
+	<dllmap dll="SDL2.dll" os="linux" cpu="x86" target="./x86/libSDL2-2.0.so.0"/>
+	<dllmap dll="soft_oal.dll" os="linux" cpu="x86" target="./x86/libopenal.so.1" />
+	<dllmap dll="SDL2.dll" os="linux" cpu="x86-64" target="./x64/libSDL2-2.0.so.0"/>
+	<dllmap dll="soft_oal.dll" os="linux" cpu="x86-64" target="./x64/libopenal.so.1" />
+</configuration>

--- a/MarsBaseBuilder.Tests/packages.config
+++ b/MarsBaseBuilder.Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Foq" version="1.7.2" targetFramework="net462" />
   <package id="FSharp.Core" version="4.1.17" targetFramework="net462" />
-  <package id="MonoGame.Framework.DesktopGL" version="3.5.1.1679" targetFramework="net462" />
+  <package id="MonoGame.Framework.DesktopGL" version="3.6.0.1625" targetFramework="net462" />
   <package id="System.ValueTuple" version="4.3.0" targetFramework="net462" />
   <package id="xunit" version="2.2.0" targetFramework="net462" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net462" />

--- a/MarsBaseBuilder/MarsBaseBuilder.fsproj
+++ b/MarsBaseBuilder/MarsBaseBuilder.fsproj
@@ -24,7 +24,7 @@
     <WarningLevel>3</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DocumentationFile>bin\$(Configuration)\$(AssemblyName).XML</DocumentationFile>
-    <Prefer32Bit>true</Prefer32Bit>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -68,22 +68,17 @@
     <Compile Include="Renderer.fs" />
     <Compile Include="MarsBaseBuilderGame.fs" />
     <Compile Include="Program.fs" />
+    <Content Include="MonoGame.Framework.dll.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MonoGame.Framework">
-      <HintPath>..\packages\MonoGame.Framework.DesktopGL.3.5.1.1679\lib\net40\MonoGame.Framework.dll</HintPath>
+      <HintPath>..\packages\MonoGame.Framework.DesktopGL.3.6.0.1625\lib\net40\MonoGame.Framework.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core">
       <Name>FSharp.Core</Name>
       <AssemblyName>FSharp.Core.dll</AssemblyName>
       <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="NVorbis">
-      <HintPath>..\packages\MonoGame.Framework.DesktopGL.3.5.1.1679\lib\net40\NVorbis.dll</HintPath>
-    </Reference>
-    <Reference Include="OpenTK">
-      <HintPath>..\packages\MonoGame.Framework.DesktopGL.3.5.1.1679\lib\net40\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/MarsBaseBuilder/MarsBaseBuilderGame.fs
+++ b/MarsBaseBuilder/MarsBaseBuilderGame.fs
@@ -1,12 +1,13 @@
 ﻿namespace MarsBaseBuilder
 
 open System
+open System.IO
 
 open Microsoft.Xna.Framework
 
 open MarsBaseBuilder.Textures
 
-type MarsBaseBuilderGame() as this =
+type MarsBaseBuilderGame(resourceBasePath : string) as this =
     inherit Game()
 
     let graphicsContext = lazy (new GraphicsContext(this.GraphicsDevice))
@@ -15,9 +16,8 @@ type MarsBaseBuilderGame() as this =
     let mutable textures = Unchecked.defaultof<TextureContainer>
 
     override this.LoadContent() =
-        let content = this.Content
-        content.RootDirectory <- "resources"
-        textures <- Textures.load content
+        let resourceDirectory = Path.Combine(resourceBasePath, "resources")
+        textures <- Textures.load resourceDirectory this.GraphicsDevice
 
     override __.Draw(gameTime) =
         use draw = graphicsContext.Value.BeginDraw()

--- a/MarsBaseBuilder/MonoGame.Framework.dll.config
+++ b/MarsBaseBuilder/MonoGame.Framework.dll.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<dllmap dll="SDL2.dll" os="osx" target="libSDL2-2.0.0.dylib"/>
+	<dllmap dll="soft_oal.dll" os="osx" target="libopenal.1.dylib" />
+	<dllmap dll="SDL2.dll" os="linux" cpu="x86" target="./x86/libSDL2-2.0.so.0"/>
+	<dllmap dll="soft_oal.dll" os="linux" cpu="x86" target="./x86/libopenal.so.1" />
+	<dllmap dll="SDL2.dll" os="linux" cpu="x86-64" target="./x64/libSDL2-2.0.so.0"/>
+	<dllmap dll="soft_oal.dll" os="linux" cpu="x86-64" target="./x64/libopenal.so.1" />
+</configuration>

--- a/MarsBaseBuilder/Program.fs
+++ b/MarsBaseBuilder/Program.fs
@@ -1,11 +1,20 @@
 ﻿module MarsBaseBuilder.Program
 
+open System
+open System.IO
+open System.Reflection
+
 open Microsoft.Xna.Framework
+
+let private getExecutableDirectoryPath () =
+    let codeBase = Uri(Assembly.GetExecutingAssembly().CodeBase)
+    Path.GetDirectoryName codeBase.AbsolutePath
 
 [<EntryPoint>]
 let main argv =
-    printfn "Starting game"
-    use game = new MarsBaseBuilderGame()
+    let path = getExecutableDirectoryPath()
+    printfn "Starting game in %s" path
+    use game = new MarsBaseBuilderGame(path)
     use graphics = new GraphicsDeviceManager(game)
 
     game.Run()

--- a/MarsBaseBuilder/Textures.fs
+++ b/MarsBaseBuilder/Textures.fs
@@ -1,11 +1,13 @@
 ﻿module MarsBaseBuilder.Textures
 
-open Microsoft.Xna.Framework.Content
+open System.IO
+
 open Microsoft.Xna.Framework.Graphics
 
 type TextureContainer = {
     builder : Texture2D
 }
     
-let load (content : ContentManager) : TextureContainer =
-    { builder = content.Load "builder" }
+let load (path : string) (graphics : GraphicsDevice) : TextureContainer =
+    use builder = new FileStream(Path.Combine(path, "builder.png"), FileMode.Open)
+    { builder = Texture2D.FromStream(graphics, builder) }

--- a/MarsBaseBuilder/packages.config
+++ b/MarsBaseBuilder/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Framework.DesktopGL" version="3.5.1.1679" targetFramework="net462" />
+  <package id="MonoGame.Framework.DesktopGL" version="3.6.0.1625" targetFramework="net462" />
   <package id="System.ValueTuple" version="4.3.0" targetFramework="net462" />
 </packages>

--- a/Readme.md
+++ b/Readme.md
@@ -19,8 +19,9 @@ Either use [Visual Studio][visual-studio] to open and build `MoonBaseBuilder.sln
 file, or invoke the following commands in developer console:
 
 ```console
-> nuget restore
-> msbuild
+$ nuget restore
+$ msbuild
+$ powershell scripts/deps-windows.ps1 # consult the script documentation, there're additional parameters
 ```
 
 ### Linux
@@ -31,6 +32,8 @@ You'll need [Mono][mono] and [NuGet][nuget] installed.
 $ nuget restore
 $ xbuild
 ```
+
+Also you should download [SDL2 dependencies][monogame-sdl] for your platform.
 
 #### NixOS
 
@@ -90,6 +93,7 @@ Attribution 4.0 International License][cc-by-license].
 [cc-by-license]: https://creativecommons.org/licenses/by/4.0/
 [imagemagick]: https://www.imagemagick.org/script/index.php
 [mono]: http://www.mono-project.com/
+[monogame-sdl]: https://github.com/MonoGame/MonoGame.Dependencies/tree/master/SDL
 [nuget]: https://www.nuget.org/
 [travis]: https://travis-ci.org/ForNeVeR/1969
 [visual-studio]: https://www.visualstudio.com/

--- a/scripts/deps-windows.ps1
+++ b/scripts/deps-windows.ps1
@@ -1,0 +1,35 @@
+<#
+.SYNOPSIS
+    Download the dependencies for Windows platform.
+.PARAMETER X64
+    Whether to download the dependencies for x64 version (by default will determine automatically).
+.PARAMETER Configuration
+    Either 'Release', 'Debug' or 'Both'. Determines the directory where the dependencies will be
+    copied.
+#>
+param (
+    [bool] $X64 = [Environment]::Is64BitOperatingSystem,
+    [string] $Configuration = 'Both',
+    [string] $SolutionPath = "$PSScriptRoot/.."
+)
+
+$ErrorActionPreference = 'Stop'
+
+$platform = if ($X64) { 'x64' } else { 'x86' }
+[string[]] $outputDirectory = if ($Configuration -eq 'Both') { @('Debug', 'Release') } else { @($Configuration) }
+
+$url = "https://github.com/MonoGame/MonoGame.Dependencies/blob/3aee602ea3dfa338edbf0f16b500cebd48c78da6/SDL/Windows/x64/SDL2.dll?raw=true"
+$response = Invoke-WebRequest -UseBasicParsing $url
+
+$outputDirectory | ForEach-Object {
+    $dir = $_
+    $path = [IO.Path]::Combine($SolutionPath, 'MarsBaseBuilder', 'bin', $dir)
+    if (-not (Test-Path $path -PathType Container)) {
+        New-Item -ItemType Directory $path
+    }
+
+    $stream = New-Object IO.FileStream "$path/SDL2.dll", 'Create'
+    $response.RawContentStream.CopyTo($stream)
+    $stream.Dispose()
+    $response.RawContentStream.Position = 0
+}


### PR DESCRIPTION
This is an important step for #17 (because the facility to control the cursor was added together with SDL2 support in MonoGame 3.6).

The main problem I got was that the native dependencies were removed from the MonoGame package, so I had to download them manually (and in my book "manually" means "by a shell script").

Other minor trouble: MonoGame's `ContentManager` now refuses to resolve PNG images, but that was easily solvable by `Texture2D.FromStream`.

For now, I encourage the Linux / macOS users to download the dependencies manually, but in future (when we'll start testing the game on these platforms) I'll add the corresponding scripts for them, too.