### PR TITLE
fsproj: fix item order, so it loads in VS

### DIFF
--- a/MarsBaseBuilder/MarsBaseBuilder.fsproj
+++ b/MarsBaseBuilder/MarsBaseBuilder.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -57,10 +57,10 @@
     <Content Include="resources\builder.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Compile Include="AssemblyInfo.fs" />
     <Content Include="resources\cursor.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Compile Include="AssemblyInfo.fs" />
     <None Include="App.config" />
     <Content Include="packages.config" />
     <Compile Include="GameUnit.fs" />


### PR DESCRIPTION
The problem consisted in the item ordering in the `fsproj` file. Visual Studio will refuse to load the project file, if it doesn't contain the directory items in one chunk (like in that example: `resources/A.png`, `AssemblyInfo`, `resources/B.png`).

@gsomix review please.